### PR TITLE
Remove tsc from dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -388,12 +388,6 @@
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
-    "tsc": {
-      "version": "1.20150623.0",
-      "resolved": "https://registry.npmjs.org/tsc/-/tsc-1.20150623.0.tgz",
-      "integrity": "sha1-Trw8d04WkUjLx2inNCUz8ILHpuU=",
-      "dev": true
-    },
     "typescript": {
       "version": "3.3.3333",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "license": "ISC",
   "devDependencies": {
     "@types/node": "^11.11.0",
-    "tsc": "^1.20150623.0",
     "typescript": "^3.3.3333"
   },
   "dependencies": {


### PR DESCRIPTION
This PR removes tsc from the devDependencies. The tsc dependency is not required since we specify typescript. Additionally, because we had specified a very low version (1.x), compilation was throwing some errors:

```
➜  lsif-util git:(master) npm run compile

> lsif-util@1.0.0 compile /Users/arjun/lsif-util
> tsc -p ./

error TS5023: Unknown compiler option 'alwaysStrict'.
error TS5023: Unknown compiler option 'esModuleInterop'.
```

These options were added in tsc 2.x.