### PR TITLE
Avoid quadratic behaviour in validate()

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -65,8 +65,10 @@ export function validate(toolOutput: LSIF.Element[], ids: string[]): number {
     checkAllVisited();
 
     if (fse.pathExistsSync(protocolPath)) {
-        checkVertices(toolOutput.filter((e : LSIF.Element) => e.type === 'vertex').map(e => e.id.toString()));
-        checkEdges(toolOutput.filter((e : LSIF.Element) => e.type === 'edge').map(e => e.id.toString()));
+        checkVertices(toolOutput.filter((e : LSIF.Element) => e.type === 'vertex')
+        .map((e: LSIF.Element) => e.id.toString()));
+        checkEdges(toolOutput.filter((e : LSIF.Element) => e.type === 'edge')
+        .map((e: LSIF.Element) => e.id.toString()));
     } else {
         console.warn('Skipping thorough validation: protocol.d.ts was not found');
     }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -65,16 +65,8 @@ export function validate(toolOutput: LSIF.Element[], ids: string[]): number {
     checkAllVisited();
 
     if (fse.pathExistsSync(protocolPath)) {
-        checkVertices(ids.filter((id: string) => {
-            const element: LSIF.Element = toolOutput.filter((e: LSIF.Element) => e.id.toString() === id)[0];
-
-            return element.type === 'vertex';
-        }));
-        checkEdges(ids.filter((id: string) => {
-            const element: LSIF.Element = toolOutput.filter((e: LSIF.Element) => e.id.toString() === id)[0];
-
-            return element.type === 'edge';
-        }));
+        checkVertices(toolOutput.filter((e : LSIF.Element) => e.type === 'vertex').map(e => e.id.toString()));
+        checkEdges(toolOutput.filter((e : LSIF.Element) => e.type === 'edge').map(e => e.id.toString()));
     } else {
         console.warn('Skipping thorough validation: protocol.d.ts was not found');
     }


### PR DESCRIPTION
The nested `filter` leads to quadratic running time, which means that [this](https://drive.google.com/file/d/1WYPTx3dBQw2G5cpdekt03AfrzBlGjv8M/view?usp=sharing) lsif file(gzipped) with ~450,000 elements fails to validate even after running for several(8+) hours.

After the changes in this PR, the same file validates in less that 30 minutes.